### PR TITLE
add _cache dir to gitignore

### DIFF
--- a/root/.gitignore
+++ b/root/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 public
+_cache


### PR DESCRIPTION
I'm guessing this should probably stay out of version control - that is, unless it needs to be checked in in order to facilitate incremental builds?