### PR TITLE
Update production config file

### DIFF
--- a/root/app.production.js
+++ b/root/app.production.js
@@ -1,5 +1,5 @@
 const OfflinePlugin = require('offline-plugin')
-const {UglifyJsPlugin, DedupePlugin} = require('webpack').optimize
+const {UglifyJsPlugin} = require('webpack').optimize
 
 module.exports = {
   // disable source maps
@@ -7,7 +7,6 @@ module.exports = {
   // webpack optimization and service worker
   plugins: [
     new UglifyJsPlugin(),
-    new DedupePlugin(),
     new OfflinePlugin({ updateStrategy: 'all' })
   ],
   // image optimization

--- a/root/assets/js/index.js
+++ b/root/assets/js/index.js
@@ -1,1 +1,3 @@
+require('offline-plugin/runtime').install()
+
 console.log('you can use ES6 here : )')

--- a/root/package.json
+++ b/root/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "ava": "^0.17.0",
+    "offline-plugin": "^4.6.1",
     "rimraf": "^2.5.4",
     "snazzy": "^6.0.0",
     "spike-core": "^0.13.3",


### PR DESCRIPTION
`DedupePlugin` is [no longer necessary in webpack 2](https://webpack.js.org/guides/migrating/#dedupeplugin-has-been-removed) so removed from production config.

`OfflinePlugin` is required, and so needs to be in `package.json` and also needs its runtime `required` in client side code. Added to `assets/js/index.js`